### PR TITLE
Made AsyncOperation accessors are thread-safe and fixed project tests

### DIFF
--- a/Develop/CompoundOperationsExampleDev/CompoundOperationsExampleDevTests/Source/Base/ChainableOperationBaseTests.m
+++ b/Develop/CompoundOperationsExampleDev/CompoundOperationsExampleDevTests/Source/Base/ChainableOperationBaseTests.m
@@ -119,7 +119,7 @@ static CGFloat const COODefaultTestTimeout = 0.1f;
     }];
     
     // when
-    [self.chainableOperationBaseMock start];
+    [(ChainableOperationBase *)self.chainableOperationBaseMock start];
     
     // then
     [self waitForExpectationsWithTimeout:COODefaultTestTimeout handler:^(NSError * _Nullable error) {
@@ -135,7 +135,7 @@ static CGFloat const COODefaultTestTimeout = 0.1f;
     }];
     
     // when
-    [self.chainableOperationBaseMock start];
+    [(ChainableOperationBase *)self.chainableOperationBaseMock start];
     
     // then
     [self waitForExpectationsWithTimeout:COODefaultTestTimeout handler:^(NSError * _Nullable error) {
@@ -152,7 +152,7 @@ static CGFloat const COODefaultTestTimeout = 0.1f;
     }];
     
     // when
-    [self.chainableOperationBaseMock start];
+    [(ChainableOperationBase *)self.chainableOperationBaseMock start];
     
     // then
     __weak __typeof__(self) weakSelf = self;
@@ -172,7 +172,7 @@ static CGFloat const COODefaultTestTimeout = 0.1f;
     }];
     
     // when
-    [self.chainableOperationBaseMock start];
+    [(ChainableOperationBase *)self.chainableOperationBaseMock start];
     
     // then
     __weak __typeof__(self) weakSelf = self;

--- a/Develop/CompoundOperationsExampleDev/CompoundOperationsExampleDevTests/Source/Base/CompoundOperationTests.m
+++ b/Develop/CompoundOperationsExampleDev/CompoundOperationsExampleDevTests/Source/Base/CompoundOperationTests.m
@@ -115,6 +115,7 @@
     // then
     OCMVerify([self.mockOperationQueue setSuspended:YES]);
     OCMVerify([self.mockOperationQueue cancelAllOperations]);
+    OCMVerify([self.mockOperationQueue setSuspended:NO]);
 }
 
 

--- a/Source/Base/CompoundOperation/CompoundOperation.m
+++ b/Source/Base/CompoundOperation/CompoundOperation.m
@@ -156,14 +156,10 @@
 - (void)cancel {
     // We should cancel the operation only if it's executing
     if (![self isFinished] && ![self isCancelled]) {
-        [super cancel];
-        
-        if ([self isExecuting]) {
-            [self finishCompoundOperationExecution];
-        }
+        [super cancel];        
+        [self finishCompoundOperationExecution];
     }
 }
-
 
 #pragma mark - <ChainableOperationDelegate>
 


### PR DESCRIPTION
Hi, guys!

-  I suggest this pull-request based on Apple's documentation, which says:
> When you subclass NSOperation, you must make sure that any overridden methods remain safe to call from multiple threads. If you implement custom methods in your subclass, such as custom data accessors, you must also make sure those methods are thread-safe. Thus, access to any data variables in the operation must be synchronized to prevent potential data corruption.
[NSOperation docs](https://developer.apple.com/reference/foundation/operation)

Analyzing the current code, you can understand that the accessors of our subclass are not fully thread safe.

- Also, I fixed compiler errors tests building and 'testThatCompoundOperationCancellsCorrectly' fails

I hope this will improve the quality of the project.
